### PR TITLE
fix hashValue crash

### DIFF
--- a/Lib/KeyHolder/RecordView.swift
+++ b/Lib/KeyHolder/RecordView.swift
@@ -264,12 +264,14 @@ public protocol RecordViewDelegate: class {
             let shiftTapped = inputModifiers.contains(.shift)
             let controlTapped = inputModifiers.contains(.control)
             let optionTapped = inputModifiers.contains(.option)
-            let totalHash = commandTapped.intValue + optionTapped.intValue + shiftTapped.intValue + controlTapped.intValue
-            if totalHash > 1 {
+            let modifiersCount = [commandTapped, optionTapped, shiftTapped, controlTapped]
+                .filter { $0 == true }
+                .count
+            if modifiersCount > 1 {
                 multiModifiers = true
                 return
             }
-            if multiModifiers || totalHash == 0 {
+            if multiModifiers || modifiersCount == 0 {
                 multiModifiers = false
                 return
             }


### PR DESCRIPTION
The hash values were used to compute how many modifiers were active. In my apps, pressing a modifier key recently produced a crash there for no apparent reason. Changing the implementation fixes that. -- The master branch already contained a fix, but adding the int-values was less obvious than my attempt, so I think this still is an improvement of the code quality.