### PR TITLE
Add support for dark mode in 10. 14 Mojave

### DIFF
--- a/Lib/KeyHolder/RecordView.swift
+++ b/Lib/KeyHolder/RecordView.swift
@@ -25,13 +25,13 @@ public protocol RecordViewDelegate: class {
 @IBDesignable open class RecordView: NSView {
 
     // MARK: - Properties
-    @IBInspectable open var backgroundColor: NSColor = .white {
+    @IBInspectable open var backgroundColor: NSColor = .controlColor {
         didSet { needsDisplay = true }
     }
     @IBInspectable open var tintColor: NSColor = .controlAccentPolyfill {
         didSet { needsDisplay = true }
     }
-    @IBInspectable open var borderColor: NSColor = .white {
+    @IBInspectable open var borderColor: NSColor = .controlColor {
         didSet { layer?.borderColor = borderColor.cgColor }
     }
     @IBInspectable open var borderWidth: CGFloat = 0 {


### PR DESCRIPTION
**Before:**
Dark mode off:
<img width="278" alt="screenshot 2019-01-06 at 14 28 36" src="https://user-images.githubusercontent.com/6180007/50736586-6c01e500-11bf-11e9-9fb3-8c1c58039575.png">
Dark mode on:
<img width="271" alt="screenshot 2019-01-06 at 14 33 57" src="https://user-images.githubusercontent.com/6180007/50736645-327da980-11c0-11e9-8c33-bcdaa9d7154e.png">

**With this change:**
Dark mode off:
<img width="278" alt="screenshot 2019-01-06 at 14 28 36" src="https://user-images.githubusercontent.com/6180007/50736586-6c01e500-11bf-11e9-9fb3-8c1c58039575.png">
Dark mode on:
<img width="276" alt="screenshot 2019-01-06 at 14 28 18" src="https://user-images.githubusercontent.com/6180007/50736592-76bc7a00-11bf-11e9-9329-42f568268e12.png">

