### PR TITLE
API changed for ease of use

### DIFF
--- a/Lib/KeyHolder/RecordView.swift
+++ b/Lib/KeyHolder/RecordView.swift
@@ -291,14 +291,14 @@ extension RecordView {
         guard window.firstResponder != self || !isRecording else { return true }
         return window.makeFirstResponder(self)
     }
-    
+
     @discardableResult
     public func endRecording() -> Bool {
         guard let window = self.window else { return true }
         guard window.firstResponder == self || isRecording else { return true }
         return window.makeFirstResponder(nil)
     }
-    
+
     private func focusView() -> Bool {
         guard isEnabled else { return false }
         if let delegate = delegate, !delegate.recordViewShouldBeginRecording(self) {
@@ -310,7 +310,7 @@ extension RecordView {
         updateTrackingAreas()
         return true
     }
-    
+
     private func unfocusView() {
         inputModifiers = NSEvent.ModifierFlags()
         isRecording = false

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ Some delegate methods
 ```swift
 func recordViewShouldBeginRecording(_ recordView: RecordView) -> Bool
 func recordView(_ recordView: RecordView, canRecordShortcut keyCombo: KeyCombo) -> Bool
-func recordViewDidClearShortcut(_ recordView: RecordView)
-func recordView(_ recordView: RecordView, didChangeKeyCombo keyCombo: KeyCombo)
+func recordView(_ recordView: RecordView, didChangeKeyCombo keyCombo: KeyCombo?)
 func recordViewDidEndRecording(_ recordView: RecordView)
 ```
 


### PR DESCRIPTION
### Breaking Changes
- Remove `delegate.recordViewDidClearShortcut()`.
-  The `KeyCombo` of `delegate.recordView(:didChangeKeyCombo:)` is now optional.

### Bugfixes
- Fix the issue that `beginRecording()` does not get focus.