### PR TITLE
Improve default colors accessibility

### DIFF
--- a/Lib/KeyHolder/Extensions/NSColorExtension.swift
+++ b/Lib/KeyHolder/Extensions/NSColorExtension.swift
@@ -11,14 +11,6 @@
 import AppKit
 
 extension NSColor {
-    static let controlAccentPolyfill: NSColor = {
-        if #available(macOS 10.14, *) {
-            return NSColor.controlAccentColor
-        } else {
-            // nmacOS 10.14 polyfill
-            return NSColor(red: 0.10, green: 0.47, blue: 0.98, alpha: 1)
-        }
-    }()
     static let clearBackgroundFill: NSColor = {
         return NSColor(red: 0.749019608, green: 0.749019608, blue: 0.749019608, alpha: 1)
     }()

--- a/Lib/KeyHolder/RecordView.swift
+++ b/Lib/KeyHolder/RecordView.swift
@@ -24,10 +24,10 @@ public protocol RecordViewDelegate: AnyObject {
 open class RecordView: NSView {
 
     // MARK: - Properties
-    @IBInspectable open var backgroundColor: NSColor = .controlColor {
+    @IBInspectable open var backgroundColor: NSColor = .textBackgroundColor {
         didSet { layer?.backgroundColor = backgroundColor.cgColor }
     }
-    @IBInspectable open var tintColor: NSColor = .controlAccentPolyfill {
+    @IBInspectable open var tintColor: NSColor = .systemBlue {
         didSet { needsDisplay = true }
     }
     @IBInspectable open var borderColor: NSColor = .controlColor {


### PR DESCRIPTION
The accent color polyfill produces a blue color when users don't change their system settings. The contrast was not sufficient with the default 3/4 dark gray background color in dark mode. Text fields usually have a deeper BG color, not lighter, when dark mode is enabled.

I suggest adopting these system defaults that look good out of the box and let client code override the app with worse colors if they want :)

## New colors

![Screen Shot 2021-04-06 at 12 59 47](https://user-images.githubusercontent.com/59080/113701432-7120a800-96d8-11eb-8951-4d6ec27f3618.png) ![Screen Shot 2021-04-06 at 12 59 57](https://user-images.githubusercontent.com/59080/113701446-75e55c00-96d8-11eb-968a-c52e09c77d85.png)


## Old colors

![Screen Shot 2021-04-06 at 13 04 05](https://user-images.githubusercontent.com/59080/113701546-97dede80-96d8-11eb-8b2b-a3a7516edfad.png) ![Screen Shot 2021-04-06 at 13 03 54](https://user-images.githubusercontent.com/59080/113701545-97464800-96d8-11eb-90c6-0f55e3107483.png)
